### PR TITLE
empty space to trigger new build

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ dask-sql Example Notebooks
 This repository contains example notebooks to showcase the usage of
 the `dask-sql` package.
 
-Main repository: [here](https://github.com/nils-braun/dask-sql).
+Main repository: [here](https://github.com/nils-braun/dask-sql). 


### PR DESCRIPTION
I'll believe there is a better way to do this but I know the image used in binder remains the same (i.e. old dask-sql) version until there are new commits in this repo.

To test: https://mybinder.org/v2/gh/raybellwaves/dask-sql-binder/raybellwaves-patch-1